### PR TITLE
fix zsh bug that did not reset vi insert or command mode status

### DIFF
--- a/polyglot.sh
+++ b/polyglot.sh
@@ -460,6 +460,7 @@ if [ -n "$ZSH_VERSION" ] && [ "${0#-}" != 'ksh' ] &&
 
   zle -N _polyglot_zle_keymap_select
   zle -A _polyglot_zle_keymap_select zle-keymap-select
+  zle -A _polyglot_zle_keymap_select zle-line-init
 
   ###########################################################
   # Redraw prompt when terminal size changes


### PR DESCRIPTION
Added _polyglot_zle_keymap_select to special widget zle-line-init to fix zsh bug that did not reset vi insert or command mode status on ctrl-c or <enter>in command mode.